### PR TITLE
Add command line interface for visualisation scripts

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,124 @@
+import argparse
+import os
+from pathlib import Path
+from typing import Dict, Union
+
+
+def custom_parser(image: bool=True, 
+               tracks: bool=False, 
+               name: bool=True, 
+               base: dict={} ) -> argparse.ArgumentParser:
+    """
+    Get an argument parser with some common arguments and, if you like, 
+    additional arguments.
+
+    Parameters
+    ----------
+    image: bool
+    tracks: bool
+    name: bool
+    base: dict
+
+    Return
+    ------
+    parser: argparse.ArgumentParser
+    """
+    parser_info = parser_dict(image=image, tracks=tracks, name=name, base=base)
+    parser = get_parser(parser_info)
+    return parser
+
+
+def get_parser(parsing_info: Dict[Union[str], dict]
+               ) -> argparse.ArgumentParser:
+    """
+    Get argparse parser from a dictionary containing necessary information
+
+    Returns
+    -------
+    parser: argparse.ArgumentParser
+
+    """
+    parser = argparse.ArgumentParser()
+    for key in parsing_info.keys():
+        arg_info = parsing_info[key]
+        arg = arg_info['name']
+        del arg_info['name']
+        if isinstance(arg, str):
+            parser.add_argument(arg, **arg_info)
+        if isinstance(arg, list):
+            parser.add_argument(arg[0], arg[1], **arg_info)
+    return parser
+
+
+def parser_dict(image: bool=True, 
+               tracks: bool=False, 
+               name: bool=True, 
+               base: dict={} ) -> Dict[Union[str], dict]:
+    """
+    Produce a dictionary with parser information. Can be provided with a base
+    dictionary 
+
+    Returns
+    -------
+    parser_info: dict of str, dict key value pairs
+
+    """
+    parser_info = base
+    if image:
+        arg = 'image'
+        name = ['-i', '--image']
+        h = "Input path to image data"
+        parser_info[arg] = {'name' : name, 
+                            'help' : h}
+    if tracks:
+        arg = 'tracks'
+        name = ['-t', '--tracks']
+        h = "Input path to tracks data"
+        parser_info[arg] = {'name': name, 
+                            'help': h}
+    if name:
+        arg = 'name'
+        name = ['-n', '--name']
+        h = 'name of user for custom hardcoded path/s'
+        parser_info[arg] = {'name': name, 
+                            'help': h}
+    return parser_info
+
+
+# Hacky Hardcoded Paths
+# ---------------------
+
+shortcuts = {
+    'Abi' : {
+        'view_tracks' : {
+            'data_path' : '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.nd2',
+            'tracks_path' : '/Users/amcg0011/GitRepos/pia-tracking/20200918-130313/tracks.csv'
+        }, 
+        'view_segmentation_3D' : {
+            'data_path' : '/Users/amcg0011/Data/pia-tracking'
+        }
+    },
+    'Juan' : {
+        'view_tracks' : {
+            'data_path' : '/Users/jni/Dropbox/share-files/200519_IVMTR69_Inj4_dmso_exp3.nd2',
+            'tracks_path' : '/Users/jni/Dropbox/share-files/tracks.csv'
+        },
+        'view_segmentation_3D' : {
+            'data_path' : '/Users/jni/Dropbox/share-files/'
+        }
+    }
+}
+
+__file__var = str
+
+def hardcoded_paths(name: str, file_: __file__var, shortcuts=shortcuts
+                    ) -> dict:
+    """
+    get the variables for 
+    """
+    file_path = os.path.realpath(file_)
+    file_name = str(Path(file_path).stem)
+    values = shortcuts[name].get(file_name)
+    return values
+
+    

--- a/view_segmentation_3D.py
+++ b/view_segmentation_3D.py
@@ -1,28 +1,15 @@
-import argparse
 import fl
 import importlib
 import napari
+from parser import custom_parser, hardcoded_paths
 
 
 # Parse args
 # ---------
-parser = argparse.ArgumentParser()
-parser.add_argument("image", help="Input path to image data")
-parser.add_argument("-n", "--name", help="Input path to tracks data")
+parser = custom_parser()
 args = parser.parse_args()
-if args.name == "Abi":
-    data_path = ( 
-    '/Users/amcg0011/Data/pia-tracking'
-    )
-
-elif args.name == "Juan":
-    data_path = ( 
-    '/Users/jni/Dropbox/share-files' # this won't work if the file isn't the first nd2 :) 
-    )
-    # elif:
-    #     data_path = 
-    #     tracks_path = 
-    # INSERT ANY OTHER SHORTCUTS :)
+if args.name:
+    data_path = hardcoded_paths(args.name, __file__)['data_path']
 else:
     data_path = args.image
 
@@ -31,7 +18,6 @@ else:
 # ---------------------
 # single frame segmentation from 1(4)_Process_images.ipynb 
 importlib.reload(fl)
-data_path = '/Users/amcg0011/Data/pia-tracking'
 df_files= fl.nd2_info_to_df(data_path)
 conf = dict(
             process_type = 'single_thread', # USE ONLY 'single_thread' for inspection


### PR DESCRIPTION
__Description__: Added command line interface for visualisation scripts using argparse. *__Note__: there are some hardcoded shortcuts at the moment.*


__view_tracks.py__
- `python view_tracks.py <path to image nd2> <path to tracks csv>`
- E.g., shortcut: `python view_tracks.py 0 0 -n "Abi"`
- Also, can view tracks with a specified threshold for the minimum number of frames in which a particle must appear to be visualised. The default is 20 based purely on intuition after scrolling though the csv.
- `python view_tracks.py <path to image nd2> <path to tracks csv> --min_frames 50`

__view_segmentation_3D.py__
- `python view_segmentation_3D.py <path to image nd2>`
- E.g., shortcut: `python view_segmentation_3D.py 0 -n "Abi"`
- *An aside: this file actually re-runs the segmentation for one frame (I may have copy-pasted)*

