### PR TITLE
Evaluation of tracking accuracy

### DIFF
--- a/_parser.py
+++ b/_parser.py
@@ -9,6 +9,7 @@ def custom_parser(image: bool=True,
                coords: bool=False,
                name: bool=True,
                save: bool=False, 
+               labels: bool=False,
                base: dict={} ) -> argparse.ArgumentParser:
     """
     Get an argument parser with some common arguments and, if you like, 
@@ -30,6 +31,7 @@ def custom_parser(image: bool=True,
                               name=name, 
                               coords=coords, 
                               save=save,
+                              labels=labels,
                               base=base)
     parser = get_parser(parser_info)
     return parser
@@ -62,6 +64,7 @@ def parser_dict(image: bool=True,
                coords: bool=False,
                name: bool=True, 
                save: bool=False,
+               labels: bool=False,
                base: dict={} ) -> Dict[Union[str], dict]:
     """
     Produce a dictionary with parser information. Can be provided with a base
@@ -101,10 +104,20 @@ def parser_dict(image: bool=True,
     if save:
         arg = 'save'
         name = ['-s','--save']
+        h = 'Input path to which to save output'
         default = 'btrack_tracks.csv'
         parser_info[arg] = {'name': name, 
                             'help': h, 
                             'default': default}
+    
+    if labels:
+        arg = 'labels'
+        name = ['-l','--labels']
+        h = 'Input a path at which to find labels file'
+        parser_info[arg] = {'name': name, 
+                            'help': h, 
+                            'default': default}
+
     return parser_info
 
 

--- a/analyse_acuracy.py
+++ b/analyse_acuracy.py
@@ -1,0 +1,165 @@
+from ast import literal_eval
+import numpy as np
+import os
+import pandas as pd
+from pathlib import Path
+
+
+def parse_table(path):
+    pass
+
+
+
+
+def add_count_data(df, col, frames_col='frames'): 
+    # because frames is what the col t-min - t-max col is called
+    if isinstance(df.loc[0, col], str):
+        # this and the following isinstance lines are a tad fragile
+        # will address this at a later date
+        lens_p = [len(list(set(literal_eval(l)))) \
+                  for l in df[col].values]
+    else:
+        m = 'Incorrect type for counting false positives'
+        assert isinstance(df.loc[0, col], list), m
+        lens_p = [len(list(set(l))) \
+                  for l in df[col].values]
+    df[col + '_count'] = lens_p
+    df[col + '_per_frame'] = df[col + '_count'] / df[frames_col]
+    return df
+
+
+def generate_summary_df(dfs):
+    col_names = [df.columns.values for df in dfs]
+    #summary_cols = np.concatenate(col_names)
+    means = [df.mean() for df in dfs]
+    summary_cols = np.unique(np.concatenate([m.index.values for m in means]))
+    sems = [df.sem() for df in dfs]
+    rows = range(len(means))
+    summary_df = {}
+    for col in summary_cols:
+        m_values = []
+        s_values = []
+        for i in range(len(rows)):
+            if col in col_names[i]:
+                new_m = means[i][col]
+                new_s = sems[i][col]
+            else:
+                new_m, new_s = np.NaN, np.NaN
+            m_values.append(new_m)
+            s_values.append(new_s)
+        summary_df[col + '_mean'] = m_values
+        summary_df[col + '_sem'] = s_values
+    summary_df = pd.DataFrame(summary_df)
+    return summary_df
+
+
+
+
+
+
+if __name__ == "__main__":
+    from _parser import custom_parser, get_paths, track_view_base
+    # -------------
+    # Btrack tracks
+    # -------------
+    d = '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_btrack-tracks'
+    fp_n = '210122_200519_IVMTR69_Inj4_dmso_exp3_btrack-tracks_0_FP_annotations.csv'
+    # false positives (swap between objects)
+    fp_p = os.path.join(d, fp_n)
+    fp = pd.read_csv(fp_p)
+    fp['t_range'] = fp['t_stop'] - fp['t_start']
+    fp = add_count_data(fp, 'FP', frames_col='t_range')
+    fp = add_count_data(fp, 'FN', frames_col='t_range')
+    # track terminations
+    tt_n = '210122_200519_IVMTR69_Inj4_dmso_exp3_btrack-tracks_0_TT_terminations_annotations.csv'
+    tt_p = os.path.join(d, tt_n)
+    tt = pd.read_csv(tt_p)
+    tt['t_range'] = tt['t_stop'] - tt['t_start']
+    tt = add_count_data(tt, 'FP', frames_col='t_range')
+    tt = add_count_data(tt, 'FN', frames_col='t_range')
+    # untracked objects
+    fn_n = '210131_200519_IVMTR69_Inj4_dmso_exp3_btrack-tracks_0_FN.csv'
+    fn_p = os.path.join(d, fn_n)
+    fn = pd.read_csv(fn_p)
+    fn_m = fn.mean()
+    # --------------
+    # tracypy tracks
+    # --------------
+    # false positives
+    d0 = '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_tracks'
+    fp0_n = '210123_200519_IVMTR69_Inj4_dmso_exp3_tracks_0_FP_annotations.csv'
+    fp0_p = os.path.join(d0, fp0_n)
+    fp0 = pd.read_csv(fp0_p)
+    fp0['t_range'] = fp0['t_stop'] - fp0['t_start']
+    fp0 = add_count_data(fp0, 'FP', frames_col='t_range')
+    fp0 = add_count_data(fp0, 'FN', frames_col='t_range')
+    # track terminations
+    tt0_n = '210123_200519_IVMTR69_Inj4_dmso_exp3_tracks_0_TT_terminations_annotations.csv'
+    tt0_p = os.path.join(d0, tt0_n)
+    tt0 = pd.read_csv(tt0_p)
+    tt0['t_range'] = tt0['t_stop'] - tt0['t_start']
+    tt0 = add_count_data(tt0, 'FP', frames_col='t_range')
+    tt0 = add_count_data(tt0, 'FN', frames_col='t_range')
+    # untracked objects
+    fn0_n = '210131_200519_IVMTR69_Inj4_dmso_exp3_tracks_0_FN.csv'
+    fn0_p = os.path.join(d0, fn0_n)
+    fn0 = pd.read_csv(fn0_p)
+    fn0_m = fn0.mean()
+    # -------------
+    # Summary Stats
+    # -------------
+    dfs = [fp, tt, fp0, tt0]
+    names = ['btrack_FP', 'btrack_TT', 'trackpy_FP', 'trackpy_TT']
+    summary = generate_summary_df(dfs)
+    summary['data'] = names
+    # ------
+    # Charts
+    # ------
+    import matplotlib.pyplot as plt
+    import matplotlib
+    x = ['BayesianTracker', 'TrackPy']
+    x_pos = [0, 1]
+    # Object swaps
+    y = [summary.loc[0, 'FP_per_frame_mean'], summary.loc[2, 'FP_per_frame_mean']]
+    sem = [summary.loc[0, 'FP_per_frame_sem'], summary.loc[2, 'FP_per_frame_sem']]
+    plt.bar(x_pos, y, color='orange', yerr=sem)
+    plt.xlabel('Software', size=20)
+    plt.ylabel('False positive events per frame', size=20)
+    matplotlib.rc('xtick', labelsize=16) 
+    matplotlib.rc('ytick', labelsize=16) 
+    plt.title('Object ID swaps in sampled tracks', size=20)
+    plt.xticks(x_pos, x)
+    plt.show()
+    # Track termination rate
+    y = [summary.loc[0, 'FN_per_frame_mean'], summary.loc[2, 'FN_per_frame_mean']]
+    sem = [summary.loc[0, 'FN_per_frame_sem'], summary.loc[2, 'FN_per_frame_sem']]
+    plt.bar(x_pos, y, color='orange', yerr=sem)
+    plt.xlabel('Software', size=20)
+    plt.ylabel('False negative events per frame', size=20)
+    matplotlib.rc('xtick', labelsize=16) 
+    matplotlib.rc('ytick', labelsize=16) 
+    plt.title('Terminations observed in sampled tracks', size=20)
+    plt.xticks(x_pos, x)
+    plt.show()
+    # Correct track termination
+    y = [summary.loc[1, 'FN_count_mean'], summary.loc[3, 'FN_count_mean']]
+    sem = [summary.loc[1, 'FN_count_sem'], summary.loc[3, 'FN_count_sem']]
+    plt.bar(x_pos, y, color='orange', yerr=sem)
+    plt.xlabel('Software', size=20)
+    plt.ylabel('False terminations per sample', size=20)
+    matplotlib.rc('xtick', labelsize=16) 
+    matplotlib.rc('ytick', labelsize=16) 
+    plt.title('False terminations per terminating track', size=20)
+    plt.xticks(x_pos, x)
+    plt.show()
+    # Correct untracked object
+    y = [fn_m['correct'] * 100, fn0_m['correct'] * 100]
+    plt.bar(x_pos, y, color='orange')
+    plt.xlabel('Software', size=20)
+    plt.ylabel('Correctly untracked objects (%)', size=20)
+    matplotlib.rc('xtick', labelsize=16) 
+    matplotlib.rc('ytick', labelsize=16) 
+    plt.title('Correctly untracked detected objects', size=20)
+    plt.xticks(x_pos, x)
+    plt.show()
+

--- a/annotate_sample.py
+++ b/annotate_sample.py
@@ -1,0 +1,676 @@
+import napari
+import numpy as np
+import os
+import pandas as pd
+from pathlib import Path
+from sampling import sample_tracks, sample_track_terminations, sample_objects
+from skimage.measure import regionprops
+from typing import Union, Iterable
+
+
+
+# ------------------
+# SampleViewer CLASS
+# ------------------
+
+
+class SampleViewer:
+    def __init__(self, 
+                 sample, 
+                 array_dict, 
+                 save_path,
+                 add_data_function,
+                 mode='Track',
+                 array_order=('t', 'x' ,'y', 'z'),
+                 time_col='t',
+                 id_col='ID',
+                 false_pos_col='FP', 
+                 false_neg_col='FN',
+                 t_start='t_start'):
+        '''
+        View and annotate a sample
+
+        Parameters
+        ----------
+        sample: dict
+            Sample information dict the form 
+            {'info' : pd.DataFrame, 
+            (ID, t) : {
+                       'df' : pd.DataFrame, 
+                       'b_box': {
+                                 '<coord name>' : slice, 
+                                 ... 
+                                 }
+                       },
+            ...
+            }
+        array_dict: dict
+            dict of arrays to be displayed and layer types. 
+            All will be sliced according to 'b_box' (above)
+            Of the form:
+            {'<name>' : {
+                         'data' : <array like>,
+                         'type' : <'image' or 'labels'>, 
+                         'scale' : tuple
+                          }, 
+            ...
+            }
+        save_path: str
+            Save the output from the annotation here. This 
+            will be the sample's info dataframe with added
+            columns: 'correct', '<false_pos_col>', <false_neg_col>'
+        array_order: tuple of str
+            reflects the order of dimensions. String labels should
+            correspond to those used in sampling process and probably
+            to 
+        
+
+        '''
+        # Prepare the image and or label data
+        names = [key for key in array_dict.keys()]
+        array = [array_dict[name]['data'] for name in names]
+        array_types = [array_dict[name]['type'] for name in names]
+        scales = [array_dict[name]['scale'] for name in names]
+        self.arrays = array
+        self.names = names
+        self.array_types = array_types
+        self.scales = scales
+        self.array_order = array_order
+        self.time_col = time_col
+        self.id_col = id_col
+
+        # sample info
+        self.sample = sample
+        self.info = sample['info']
+        self.false_pos_col = false_pos_col # add FPs
+        self.false_neg_col = false_neg_col # add FNs
+        self.t_start = t_start
+        self._add_annotation_cols()
+        self.save_path = save_path # where the output goes
+        
+        # get the list of slices that will be used to display samples 
+        self.pairs = [key for key in sample.keys() if isinstance(key, tuple)]
+        self.slices = self._get_slices()
+        self._i = 0
+
+        # initialise viewer attr
+        self.v = None
+
+        # Add data (track, points, etc)
+        self.mode = mode
+        self.add_data_function = add_data_function
+
+
+    def _add_annotation_cols(self):
+        rl_info = range(len(self.info))
+        corr = [None for _ in rl_info]
+        fp = [[] for _ in rl_info]
+        fn = [[] for _ in rl_info]
+        self.info['correct'] = corr
+        self.info[self.false_pos_col] = fp
+        self.info[self.false_neg_col] = fn
+
+
+
+    def _get_slices(self):
+        slices = []
+        for pair in self.pairs:
+            s = []
+            for coord in self.array_order:
+                s.append(self.sample[pair]['b_box'][coord])
+            slices.append(tuple(s))
+        return slices
+
+
+    @property
+    def i(self):
+        return self._i
+
+
+    @i.setter
+    def i(self, i):
+        if i < len(self.slices) or i > 0:
+            self._i = i
+        else:
+            print('invalid sample index')
+
+
+    def _add_data(self):
+        """
+        Function to add data. Must take viewer, sample dict, and pair
+        """
+        self.add_data_function(self)
+
+
+    def annotate(self):
+        with napari.gui_qt():
+            self._show_sample()
+            self.v.bind_key('y', self.yes)
+            self.v.bind_key('n', self.no)
+            self.v.bind_key('d', self.next)
+            self.v.bind_key('a', self.previous)
+            # on the frame after a swap assign the frame number
+                # to the ID swap list
+            self.v.bind_key('i', self.false_positive)
+            self.v.bind_key('Shift-i', self.false_negative)
+
+
+    def _show_sample(self):
+        # initialise the viewer if it doesnt exist
+        if self.v is None:
+            self.v = napari.Viewer()
+            print('---------------------------------------------------------')
+            print(f"Showing sample 1/{len(self.slices)}")
+            print('---------------------------------------------------------')
+            m = 'Mark samples as correct or incorrect by pressing y or n, '
+            print(m)
+            m = 'repspectively'
+            print(m)
+            print('---------------------------------------------------------')
+            m = 'Indicate a false positive or false negative has occured'
+            print(m)
+            m = 'by pressing i or Shift-i, respectively. Doing so will'
+            print(m)
+            m = 'record the frame index in which the error occured'
+            print(m)
+        # get the slices representing the current track
+        s_ = self.slices[self._i]
+        # get the names of layers currently attached to the viewer
+        layer_names = [l.name for l in self.v.layers]
+        prop = {}
+        # iterate through the layers to be added
+        for i, name in enumerate(self.names):
+            if name not in layer_names:
+                t = self.array_types[i]
+                scale = self.scales[i]
+                if t == 'image':
+                    print(self.arrays[i][s_])
+                    img = np.array(self.arrays[i][s_])
+                    self.v.add_image(img, 
+                                     name=name, 
+                                     scale=scale, 
+                                     colormap='bop orange')
+                elif t == 'labels':
+                    labs = np.array(self.arrays[i][s_])
+                    print(labs.shape)
+                    self.v.add_labels(labs, 
+                                      name=name, 
+                                      scale=scale)
+                else:
+                    raise ValueError(f'No support for layer type {t}')
+            else:
+                self.v.layers[name].data = self.arrays[i][s_]
+        self._add_data()
+        
+
+
+    # For Key Binding
+    #----------------
+
+    def yes(self, viewer):
+        """
+        Annotate as correct. Will be bound to key 'y'
+        """
+        self._annotate(1)
+        self._check_ann_status()
+    
+    def no(self, viewer):
+        """
+        Annotate as incorrect. Will be bound to key 'n'
+        """
+        self._annotate(0)
+        self._check_ann_status()
+
+    def next(self, viewer):
+        """
+        Move to next pair. Will be bound to key 'd'
+        """
+        print(f'next')
+        self._next()
+
+    def previous(self, viewer):
+        """
+        Move to previous pair. Will be bound to key 'a'
+        """
+        print(f'previous')
+        self._previous()
+    
+
+    def false_positive(self, viewer):
+        """
+        Get the time frame at which ID swap happended
+        """
+        t = self._get_current()
+        self.info[self.false_pos_col][self._i].append(t)
+        print(f'False positive recorded at time {t}')
+        if self.save_path is not None:
+            self.info.to_csv(self.save_path)
+
+    
+    def false_negative(self, viewer):
+        """
+        Get the time frame at which ID swap happended
+        """
+        t = self._get_current()
+        self.info[self.false_neg_col][self._i].append(t)
+        print(f'False negative recorded at time {t}')
+        if self.save_path is not None:
+            self.info.to_csv(self.save_path)
+
+
+    # Key binding helpers
+    # -------------------
+
+    def _next(self):
+        penultimate = len(self.slices) - 2
+        if self._i <= penultimate:
+            self._i += 1
+            self._show_sample()
+            print('---------------------------------------------------------')
+            print(f"Showing sample {self._i + 1}/{len(self.slices)}")
+        else:
+            print('---------------------------------------------------------')
+            print(f"Showing sample {self._i + 1}/{len(self.slices)}")
+            self._check_ann_status()
+            print("To navagate to prior samples press the a key")
+
+    
+    def _previous(self):
+        if self._i >= 1:
+            self._i -= 1
+            self._show_sample()
+            print('---------------------------------------------------------')
+            print(f"Showing sample {self._i + 1}/{len(self.slices)}")
+        else:
+            print('---------------------------------------------------------')
+            print(f"Showing sample {self._i + 1}/{len(self.slices)}")
+            self._check_ann_status()
+            print("To navagate to the next sample press the d key")
+
+
+    def _annotate(self, ann):
+        word = lambda a : 'correct' if a == 1 else 'incorrect'
+        self.info.at[self.i, 'correct'] = ann
+        print(f'{self.mode} was marked {word(ann)}')
+        self._get_score()
+        if self.save_path is not None:
+            self.info.to_csv(self.save_path) 
+        self._next()
+
+
+    def _get_current(self):
+        current = self.v.dims.current_step[0]
+        t0 = self.info[self.t_start][self._i]
+        t = current + t0
+        return t
+
+
+    def _check_ann_status(self):
+        out = self.info['correct'].values
+        if None not in out:
+            print('---------------------------------------------------------')
+            print('All tracks have been annotated')
+            print(f'Final score is {self.score * 100} %')
+        elif None in out and self._i + 1 > len(out):
+            not_done = []
+            for i, o in enumerate(out):
+                if o == None:
+                    not_done.append(i)
+            if len(not_done) == 1:
+                print('---------------------------------------------------------')
+                print(f'Track {not_done[0]} of {len(out)} has not yet been annotated')
+            if len(not_done) > 1:
+                print('---------------------------------------------------------')
+                print(f'Tracks {not_done} of {len(out)} have not yet been annotated')
+
+
+    def _get_score(self):
+            """
+            Get the proportion of correctly scored tracks
+            """
+            self.score = np.divide(self.info['correct'].sum(), len(self.info))
+
+
+# ---------------------------
+# ANNOTATE TRACKS - POSITIVES
+# ---------------------------
+
+
+def annotate_tracks(
+                    df, 
+                    image, 
+                    save_path,
+                    labels=None,
+                    n_samples=30,
+                    frames=30, 
+                    box=60, 
+                    id_col='ID',
+                    time_col='t', 
+                    array_order=('t', 'x' ,'y', 'z'),
+                    scale=(1,1,1,4),
+                    non_tzyx_col=None, 
+                    seed=None,
+                    weights=None, 
+                    max_lost_prop=1.0,
+                    min_track_length=20, # pick a number under which tracks are likely to be spurious
+                    false_pos_col='FP', 
+                    false_neg_col='FN',
+                    **kwargs
+                    ):
+    p = Path(save_path)
+    save_path = os.path.join(p.parents[0], p.stem + '_annotations.csv')
+    sample_save_path = os.path.join(p.parents[0], p.stem + '_sample.csv')
+    sample = sample_tracks(
+                           df, 
+                           image, 
+                           'Tracks', 
+                           n_samples, 
+                           frames, 
+                           box, 
+                           id_col, 
+                           time_col, 
+                           array_order, 
+                           scale, 
+                           non_tzyx_col, 
+                           seed, 
+                           weights, 
+                           max_lost_prop, 
+                           min_track_length,
+                           ** kwargs)
+    # so that the sample can be revieved if need be
+    # save_sample_info(sample_save_path, sample)
+    # print('++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++')
+    # print(sample)
+    array_dict = {
+        'Image' : {
+                   'data' : image, 
+                   'type' : 'image',
+                   'scale' : scale
+                   },
+                  }
+    if labels is not None:
+        array_dict['Labels'] = {
+                                'data' : labels, 
+                                'type' : 'labels',
+                                'scale' : scale
+                                }
+    sv = SampleViewer( 
+                      sample, 
+                      array_dict, 
+                      save_path,
+                      add_track_data,
+                      mode='Track',
+                      array_order=('t', 'x' ,'y', 'z'),
+                      false_pos_col=false_pos_col, 
+                      false_neg_col=false_neg_col,
+                      t_start='t_start', # this will be the name of the column in
+                      )                  # in which the time slice.start is stored
+                                    # as is outputted by the sample_tracks fnc
+    sv.annotate()
+    return sv.info
+
+
+def annotate_track_terminations(df, 
+                                image, 
+                                save_path,
+                                labels=None,
+                                n_samples=30,
+                                frames=30, 
+                                box=60, 
+                                id_col='ID',
+                                time_col='t', 
+                                array_order=('t', 'x' ,'y', 'z'),
+                                scale=(1,1,1,4),
+                                non_tzyx_col=None, 
+                                seed=None,
+                                weights=None, 
+                                max_lost_prop=1.0,
+                                min_track_length=20, # pick a number under which tracks are likely to be spurious
+                                false_pos_col='FP', 
+                                false_neg_col='FN',
+                                **kwargs):
+    print('Obtaining terminating tracks')
+    # t
+    p = Path(save_path)
+    # The line below is for use in evaluate_tracks.py. 
+    # In general, this is a silly way to construct a name
+    save_all = os.path.join(p.parents[0], p.stem[7:] + '_with-terminating.csv')
+    if not os.path.exists(save_all):
+        # find terminating tracks and add weights
+        unique_ids = df[id_col].unique()
+        # set weights for sampling to zero by default
+            # pandas won't include zeros weights
+        terminating = [0] * len(df)
+        df['terminating'] = terminating
+        counter = 0
+        for ID in unique_ids:
+            counter += 1
+            id_df = df.loc[(df[id_col] == ID)]
+            id_df = id_df.sort_values(time_col)
+            row = id_df.iloc[[-1]]
+            i = row.index[0]
+            # assume each ID appears once at each timepoint
+            ID, t = row.loc[i, id_col], row.loc[i, time_col]
+            for idx, dim in enumerate(array_order):
+                if dim == time_col:
+                    t_idx = idx
+            if t < image.shape[t_idx] - 1:
+                i = df.loc[(df[id_col] == ID) & (df[time_col] == t)].index[0]
+                # weight for sampling set to one
+                df.loc[i, 'terminating'] = 1
+        print(f'{counter} track terminations identified.')
+        df.to_csv(save_all)
+    else:
+        df = pd.read_csv(save_all)
+    save_path = os.path.join(p.parents[0], p.stem + '_terminations.csv')
+    info = annotate_tracks(
+                           df, 
+                           image, 
+                           save_path,
+                           labels=labels,
+                           n_samples=n_samples,
+                           frames=frames, 
+                           box=box, 
+                           id_col=id_col,
+                           time_col=time_col, 
+                           array_order=array_order,
+                           scale=scale,
+                           non_tzyx_col=non_tzyx_col, 
+                           seed=seed,
+                           weights='terminating', 
+                           max_lost_prop=max_lost_prop,
+                           min_track_length=min_track_length, 
+                           # pick a number under which tracks 
+                           #      are likely to be spurious
+                           false_pos_col=false_pos_col, 
+                           false_neg_col=false_neg_col,
+                           **kwargs
+                           )
+    return info
+
+
+
+def add_track_data(sv):
+    viewer = sv.v
+    sample = sv.sample
+    pair = sv.pairs[sv._i]
+    layer_names = [l.name for l in viewer.layers]
+    data = sample[pair]['tracks']
+    prop = {'track_id': data[:, 0]}
+    if 'Tracks' not in layer_names:
+        viewer.add_tracks(
+                          data, 
+                          properties=prop,
+                          color_by='track_id',
+                          name='Tracks', 
+                          colormap='viridis', 
+                          tail_width=6, 
+                          )
+    else:
+        #i = [i for i, name in enumerate(layer_names) if name == 'Tracks']
+        #viewer.layers.pop(i[0])
+        #viewer.add_tracks(
+         #                 data, 
+          #                properties=prop,
+           #               color_by='track_id',
+            #              name='Tracks', 
+             #             colormap='viridis', 
+              #            tail_width=6, 
+               #           )
+        viewer.layers.properties = prop
+        viewer.layers.color_by = 'track_id'
+        viewer.layers['Tracks'].data = data
+        viewer.layers.color_by = 'track_id'
+
+
+
+
+
+
+# ---------------------------
+# ANNOTATE TRACKS - NEGATIVES
+# ----------------------------
+
+def annotate_object_tracks(tracks_df, 
+                           image, 
+                           save_path,
+                           labels,
+                           n_samples=30,
+                           frames=30, 
+                           box=60, 
+                           id_col='ID',
+                           time_col='t', 
+                           array_order=('t', 'x' ,'y', 'z'),
+                           scale=(1,1,1,4),
+                           non_tzyx_col=None, 
+                           seed=None,
+                           weights=None, 
+                           max_lost_prop=1.0,
+                           min_track_length=20, # pick a number under which tracks are likely to be spurious
+                           false_pos_col='FP', 
+                           false_neg_col='FN',
+                           **kwargs
+                           ):
+    """
+    Take a random sample of objects and assess associated false negatives
+    and false positives assocaited with that object. 
+    """
+    p = Path(save_path)
+    print('Obtaining detected object sample...')
+    save_all = os.path.join(p.parents[0], p.stem[7:] + '_with-terminating.csv')
+    t_idx = [i for i, c in enumerate(array_order) if c == time_col][0]
+    if not os.path.exists(save_all):
+        df = {
+            'ID': [], 
+            'area': [], 
+            }
+        for coord in array_order:
+            df[coord] = []
+        t_max = labels.shape[t_idx]
+        s_ = [slice(None, None)]*len(labels.shape) 
+        sans_t_coord = [c for c in array_order if c != time_col]
+        # Enter the for loop from hell =P
+        counter = 0
+        for t in range(t_max):
+            try:
+                # get a single frame at a time
+                s_[t_idx] = slice(t, t+1)
+                s_tup = tuple(s_)
+                labs = np.array(labels[s_tup])
+                labs = np.squeeze(labs)
+                props = regionprops(labs)
+                # ID with some properties. Could correlate the 
+                for i, obj in enumerate(props):
+                    # dummy IDs because ID counts are restarted each frame
+                    assert i + counter not in df['ID']
+                    df['ID'].append(i + counter)
+                    df['area'].append(obj['area'])
+                    for i, coord in enumerate(sans_t_coord):
+                        df[coord].append(obj['centroid'][i])
+                    df[time_col].append(t)
+                    counter += 1
+            except:
+                print(f'File not found for t == {t}')
+        assert len(list(set(df['ID']))) == len(df['ID'])
+        df = pd.DataFrame(df)
+        df.to_csv(save_all)
+    else:
+        df = pd.read_csv(save_all)
+    sample = sample_objects(#df,
+                          tracks_df,
+                          labels,
+                          image, 
+                          'Objects',
+                          n_samples,
+                          frames, 
+                          box,
+                          id_col, 
+                          time_col, 
+                          array_order, 
+                          scale, 
+                          non_tzyx_col,
+                          seed,
+                          max_lost_prop,
+                          **kwargs)
+    array_dict = {
+        'Image' : {
+                   'data' : image, 
+                   'type' : 'image',
+                   'scale' : scale
+                   },
+                  }
+    array_dict['Labels'] = {
+                            'data' : labels, 
+                            'type' : 'labels',
+                            'scale' : scale
+                            }
+    sv = SampleViewer( 
+                      sample, 
+                      array_dict, 
+                      save_path,
+                      add_tracks_and_object_mask,
+                      mode='Track',
+                      array_order=('t', 'x' ,'y', 'z'),
+                      false_pos_col=false_pos_col, 
+                      false_neg_col=false_neg_col,
+                      t_start='t_start', # this will be the name of the column in
+                      ) 
+    sv.annotate()
+    return sv.info
+
+
+def add_tracks_and_object_mask(sv: SampleViewer):
+    '''
+    Add tracks and an additional labels layer with a
+    mask for the sampled object
+    '''
+    add_track_data(sv)
+    # compute and add mask
+    viewer = sv.v
+    layer_names = [l.name for l in viewer.layers]
+    for i, name in enumerate(sv.names):
+        if name == 'Labels':
+            scale = sv.scales[i]
+            labels = sv.arrays[i]
+    assert labels is not None, 'No labels layer supplied'
+    # mask for the object ID
+    pair = sv.pairs[sv._i]
+    labs = np.array(viewer.layers['Labels'].data)
+    mask = labs == pair[0]
+    if 'Object' not in layer_names:
+        viewer.add_labels(mask, 
+                          name='Object')
+    else:
+        viewer.layers['Object'].data = mask
+    if sv.info.loc[sv._i, 'n_objects'] == None:
+        labs = viewer.layers['Labels'].data
+        n = 0
+        for t in range(labs.shape[0]):
+            l = np.array(labs[t])
+            n += np.unique(l).size - 1
+            # - 1 because 0 will be a unique entity
+        sv.info.loc[sv._i, 'n_objects'] = n 
+    if sv.info.loc[sv._i, 'frames'] == None:
+        f = np.array(viewer.layers['Labels'].data).shape[0]
+        sv.info.loc[sv._i, 'frames'] = f
+

--- a/evaluate_tracks.py
+++ b/evaluate_tracks.py
@@ -1,30 +1,291 @@
-from _parser import custom_parser, get_paths, track_view_base
-from annotate_tracks import annotate
+from ast import literal_eval
+from datetime import date
+import dask.array as da
+from glob import glob
+import numpy as np
 import os
-from random_tracks_engine import get_random_tracks, read_data
+import pandas as pd
+from pathlib import Path
+from annotate_sample import annotate_track_terminations, annotate_tracks, annotate_object_tracks
 
 
-# argparse parse arguments 
-#    - image data + tracks data + output directory 
-parser = custom_parser(image=True, tracks=True, save=True)
-args = parser.parse_args()
-paths = get_paths(
-                  args, 
-                  'random_tracks_engine',
-                  get={'data_path':'image', 
-                       'tracks_path':'tracks',
-                       'save_dir':'save', 
-                       }, 
-                  by_name=True
-                  )
-# get random tracks from tracks and volume
-prefix = 'weighted_random_tracks'
-arr, tracks, df = get_random_tracks(paths, prefix, n=15)
-# save annotation output with designated suffix
-save_path = os.path.join(paths['save_dir'], prefix + '_annotated.csv')
-# annotate some random tracks
-annotate(arr, tracks, df, save_path)
+def evaluate_tracks(tracks, 
+                    image, 
+                    save_path,
+                    labels=None,
+                    n_samples=30,
+                    frames=30, 
+                    box=60, 
+                    id_col='ID',
+                    time_col='t', 
+                    array_order=('t', 'x' ,'y', 'z'),
+                    scale=(1,1,1,4),
+                    non_tzyx_col=None, 
+                    seed=None,
+                    weights=None, 
+                    max_lost_prop=1.0,
+                    min_track_length=20, # pick a number under which tracks are likely to be spurious
+                    false_pos_col='FP', 
+                    false_neg_col='FN',
+                    **kwargs
+                    ):
+    """
+    Three stage process (stages 1 and 2 complete)
+        1) incorrect assignments - false positive
+        2) incorrect termination -  false negative 
+        3) failure to link objects - false negative 
 
-# '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_Position.csv'
-# '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr'
-# '/Users/amcg0011/Data/pia-tracking/rand' # need to add makedir 
+    Parameters
+    ----------
+    tracks: pd.DataFrame 
+    image: array-like
+    save_path: str
+    labels: None or array-like (int),
+    n_samples: int,
+    frames: int, 
+    box: int, 
+    id_col: str,
+    time_col: str, 
+    array_order: tuple of str
+        E.g., ('t', 'x' ,'y', 'z') or ('c', 't', 'x' ,'y', 'z'). 
+        Should correspond to names of columns in track data.
+    scale: tuple of int,
+    non_tzyx_col: str or tuple of str, 
+    seed: None or int,
+    weights: None or str, 
+    max_lost_prop: float,
+    min_track_length: int,
+        Name a bit misleading. Refers to the min number of frames in which a
+        track appears. 
+    false_pos_col: str,
+        Name of the column in which the instances of false positives will be 
+        stored in annotation output csv. 
+    false_neg_col:
+        Name of the column in which the instances of false negatives will be 
+        stored in annotation output csv.
+    """
+    os.makedirs(save_path, exist_ok=True)
+    save_FP = get_new_path(save_path, '_FP.csv', 0)
+    print('---------------------------------------------------------')
+    info_FP = annotate_tracks(
+                              tracks, 
+                              image, 
+                              save_FP,
+                              labels=labels,
+                              n_samples=n_samples,
+                              frames=frames, 
+                              box=box, 
+                              id_col=id_col,
+                              time_col=time_col, 
+                              array_order=array_order,
+                              scale=scale,
+                              non_tzyx_col=non_tzyx_col, 
+                              seed=seed,
+                              weights=weights, 
+                              max_lost_prop=max_lost_prop,
+                              min_track_length=min_track_length,
+                              false_pos_col=false_pos_col, 
+                              false_neg_col=false_neg_col,
+                              **kwargs
+                              )
+    save_TT = get_new_path(save_path, '_TT.csv', 0)
+    print('---------------------------------------------------------')
+    info_TT = annotate_track_terminations(tracks, 
+                                          image, 
+                                          save_TT,
+                                          labels=labels,
+                                          n_samples=n_samples,
+                                          frames=frames, 
+                                          box=box, 
+                                          id_col=id_col,
+                                          time_col=time_col, 
+                                          array_order=array_order,
+                                          scale=scale,
+                                          non_tzyx_col=non_tzyx_col, 
+                                          seed=seed,
+                                          weights=weights, 
+                                          max_lost_prop=max_lost_prop,
+                                          min_track_length=min_track_length,
+                                          false_pos_col=false_pos_col, 
+                                          false_neg_col=false_neg_col,
+                                          **kwargs)
+    save_FN = get_new_path(save_path, '_FN.csv', 0)
+    print('---------------------------------------------------------')
+    hlf_frames = 16
+    info_FN = annotate_object_tracks(tracks, 
+                                     image, 
+                                     save_FN,
+                                     labels,
+                                     n_samples=n_samples,
+                                     frames=hlf_frames, 
+                                     box=box, 
+                                     id_col=id_col,
+                                     time_col=time_col, 
+                                     array_order=array_order,
+                                     scale=scale,
+                                     non_tzyx_col=non_tzyx_col, 
+                                     seed=seed,
+                                     weights=weights, 
+                                     max_lost_prop=max_lost_prop,
+                                     min_track_length=min_track_length,
+                                     false_pos_col=false_pos_col, 
+                                     false_neg_col=false_neg_col,
+                                     **kwargs)
+    dfs = [info_FP, info_TT, info_FN]
+    for i, df in enumerate(dfs):
+        for col in [false_pos_col, false_neg_col]:
+            df = add_count_data(df, col, frames_col='frames')
+            dfs[i] = df
+    summary_df = generate_summary_df(dfs)
+    sample = ['FP', 'TT', 'FN']
+    summary_df.loc[:, 'Sample'] = sample
+    summary_df = summary_df.set_index('Sample')
+    save_summary = get_new_path(save_path, '_summary.csv', 0)
+    summary_df.to_csv(save_summary)
+    print('---------------------------------------------------------')
+    print(f'Summary saved at {save_summary}')
+    return dfs
+
+
+def read_positives_data(data_dir):
+    # LOL, why not glob? 
+    annotations = [f for f in os.listdir(data_dir) if f.endswith('_annotation.csv')]
+    df = pd.concat([pd.read_csv(os.path.join(data_dir, a)) for a in annotations])
+    return df
+
+
+# Helpers
+# -------
+
+def get_new_path(save_path, suffix, n):
+    d = date.today().strftime('%y%m%d')
+    p = Path(save_path)
+    nm =  d + '_' + p.stem + '_' + str(n) + suffix
+    new = os.path.join(save_path, nm)
+    files = os.listdir(save_path)
+    v = [True for f in files if f.find(nm) != -1]
+    if True in v:
+        n +=1
+        return get_new_path(save_path, suffix, n)
+    elif True not in v:
+        return new
+
+
+def add_count_data(df, col, frames_col='frames'): 
+    # because frames is what the col t-min - t-max col is called
+    if isinstance(df.loc[0, col], str):
+        # this and the following isinstance lines are a tad fragile
+        # will address this at a later date
+        lens_p = [len(list(set(literal_eval(l)))) \
+                  for l in df[col].values]
+    else:
+        m = 'Incorrect type for counting false positives'
+        assert isinstance(df.loc[0, col], list), m
+        lens_p = [len(list(set(l))) \
+                  for l in df[col].values]
+    df[col + '_count'] = lens_p
+    df[col + '_per_frame'] = df[col + '_count'] / df[frames_col]
+    return df
+
+
+def generate_summary_df(dfs):
+    col_names = [df.columns.values for df in dfs]
+    #summary_cols = np.concatenate(col_names)
+    means = [df.mean() for df in dfs]
+    summary_cols = np.unique(np.concatenate([m.index.values for m in means]))
+    sems = [df.sem() for df in dfs]
+    rows = range(len(means))
+    summary_df = {}
+    for col in summary_cols:
+        m_values = []
+        s_values = []
+        for i in range(len(rows)):
+            if col in col_names[i]:
+                new_m = means[i][col]
+                new_s = sems[i][col]
+            else:
+                new_m, new_s = np.NaN, np.NaN
+            m_values.append(new_m)
+            s_values.append(new_s)
+        summary_df[col + '_mean'] = m_values
+        summary_df[col + '_sem'] = s_values
+    summary_df = pd.DataFrame(summary_df)
+    return summary_df
+
+
+if __name__ == "__main__":
+    from _parser import custom_parser, get_paths, track_view_base
+    from data_io import single_zarr
+    #
+    # argparse parse arguments 
+    #    - image data + tracks data + output directory 
+    parser = custom_parser(image=True, tracks=True, save=True, labels=True)
+    args = parser.parse_args()
+    paths = get_paths(
+                      args, 
+                      'random_tracks_engine',
+                      get={'data_path':'image', 
+                           'tracks_path':'tracks',
+                           'save_dir':'save', 
+                           'labels_path': 'labels'
+                           }, 
+                      by_name=True
+                      )
+    # get random tracks from tracks and volume
+    tracks_path = paths['tracks_path']
+    tracks = pd.read_csv(tracks_path)
+    image_path = paths['data_path']
+    image = single_zarr(image_path)
+    out_dir = paths['save_dir']
+    prefix = Path(image_path).stem + '_' + Path(tracks_path).stem
+    save_path = os.path.join(out_dir, prefix)
+    labels_path = paths['labels_path']
+    labels = da.from_zarr(labels_path)
+    print(f'Output will be saved at {save_path}')
+    dfs = evaluate_tracks(tracks, 
+                          image, 
+                          save_path, 
+                          n_samples=30, 
+                          labels=labels)
+
+
+
+
+    #evaluate_positives(tracks_path, 
+                     #  image_path, 
+                     #  out_dir,
+                     #  prefix, 
+                     #  n_frames=[70,],
+                     #  box_sizes=[80,], 
+                     #  sample_size=3, 
+                     #  id_col='ID', 
+                     #  time_col='t', 
+                     #  array_order=('t', 'x', 'y', 'z'), 
+                     #  scale=(1, 1, 1, 4), 
+                     #  )
+     
+    #data_dir = os.path.join(out_dir, prefix)
+    # df = read_positives_data(data_dir)
+    # positives_descriptives(df, data_dir, prefix)
+
+    # -i /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr -t /Users/amcg0011/GitRepos/pia-tracking/20200918-130313/btrack-tracks.csv -s /Users/amcg0011/Data/pia-tracking/
+    # -i /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr -t /Users/amcg0011/GitRepos/pia-tracking/20200918-130313/tracks.csv -s /Users/amcg0011/Data/pia-tracking/
+    # /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_btrack-tracks
+    # /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_tracks
+    # OLD
+    # ---
+    #arr, tracks, df = get_random_tracks(paths, prefix, n=15)
+    # save annotation output with designated suffix
+    #save_path = os.path.join(paths['save_dir'], prefix + '_annotated.csv')
+    # annotate some random tracks
+    #annotate(arr, tracks, df, save_path)
+
+    # '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_Position.csv'
+    # '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr'
+    # '/Users/amcg0011/Data/pia-tracking/rand' # need to add makedir \
+
+    # python evaluate_tracks.py \
+    # -i /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr \
+    # -t /Users/amcg0011/GitRepos/pia-tracking/20200918-130313/btrack-tracks.csv \
+    # -s /Users/amcg0011/Data/pia-tracking/
+

--- a/ipython_scripts/201116_imaris-tracks.py
+++ b/ipython_scripts/201116_imaris-tracks.py
@@ -1,0 +1,20 @@
+import napari
+import pandas as pd
+
+
+filename = '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.nd2'
+tracks_filename = '/Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_Position.csv'
+
+track_positions = pd.read_csv(tracks_filename, header=0, skiprows=(0, 1, 2))
+tracks = track_positions.sort_values(['TrackID', 'Time'])
+tracks['Time'] -= 1  # Imaris uses 1-indexing
+columns = ['TrackID', 'Time'] + [f'Position {i}' for i in 'ZYX']
+
+with napari.gui_qt():
+    v = napari.Viewer()
+    layers = v.open(filename)
+    v.add_tracks(
+        tracks[columns].to_numpy(),
+        properties=tracks,
+        color_by='TrackID',
+    )

--- a/outdated/annotate_tracks.py
+++ b/outdated/annotate_tracks.py
@@ -1,0 +1,326 @@
+import napari
+import numpy as np 
+import pandas as pd 
+from random_tracks_engine import RandomTracksEngine
+from view_tracks import get_tracks
+
+
+# -----------------------------------------------------------------------------
+# TrackViewer Class
+# -----------------
+
+class TrackViewer:
+    def __init__(self, 
+                 hypercubes, 
+                 tracks_list, 
+                 df, 
+                 save_path,
+                 im_scale=(1, 1, 1, 4),
+                 id_col='ID', 
+                 time_col='t', 
+                 out_col='correct', 
+                 swap_col='ID_swaps', 
+                 t_start='t_start'):
+        '''
+        View and annotate individual tracks
+
+        Parameters
+        '''
+        # Data
+        # ----
+        self.array = None
+        self.tracks = None
+        self.df = None
+
+        # Current track
+        # -------------
+        self.viewer = None
+        self.i = None
+        self.current = None
+
+        # Column names
+        # ------------
+        self.id_col = id_col
+        self.time_col = time_col
+        self.out_col = out_col
+        self.swap_col = swap_col
+        self.t_start = t_start
+
+        # Assign Vals
+        # -----------
+        self._data = self._set_data(hypercubes, tracks_list, df)
+        self.im_scale = im_scale
+
+        # Save
+        # ----
+        self.save_path = save_path
+
+    # Data
+    # ----
+
+    @property
+    def data(self):
+        return self._data
+
+
+    @data.setter
+    def data(self, data):
+        hypercubes, tracks_list, df = data
+        self._set_data(hypercubes, tracks_list, df)
+
+
+    def _set_data(self, hypercubes, tracks_list, df):
+        if hypercubes is not None:
+            self.array = hypercubes
+        if tracks_list is not None:
+            self.tracks = tracks_list
+        if df is not None:
+            df[self.out_col] = [None for _ in range(len(df))]
+            df[self.swap_col] = [[] for _ in range(len(df))]
+            df['idx'] = [i for i in range(len(df))]
+            df = df.set_index('idx')
+            self.df = df
+        if df is not None:
+            self._initialise_current()
+        self._data = self.array, self.tracks, self.df
+        return self._data
+
+    def _initialise_current(self):
+        self.i = 0
+        ID = self.df[self.id_col][0]
+        t = self.df[self.time_col][0]
+        self.current = (ID, t)
+
+
+    # this method executes all other methods
+    def annotate(self):
+        with napari.gui_qt():
+            if self.viewer is None:
+                self.viewer = napari.Viewer()
+            if len(self.viewer.layers) != 0:
+                self._clear_viewer(self.viewer)
+            self._show_track(self.viewer)
+            print(f'Showing track 1 of {len(self.df)}')
+            #self.viewer.unselect_all()
+            self.viewer.bind_key('y', self.yes)
+            self.viewer.bind_key('n', self.no)
+            self.viewer.bind_key('d', self.next)
+            self.viewer.bind_key('a', self.previous)
+            # on the frame after a swap assign the frame number
+                # to the ID swap list
+            self.viewer.bind_key('i', self.add_id_swap)
+
+
+    # For Key Binding
+    #----------------
+
+    def yes(self, viewer):
+        """
+        Annotate as correct. Will be bound to key 'y'
+        """
+        self._annotate(1, viewer)
+    
+    def no(self, viewer):
+        """
+        Annotate as incorrect. Will be bound to key 'n'
+        """
+        self._annotate(0, viewer)
+
+    def next(self, viewer):
+        """
+        Move to next pair. Will be bound to key 'd'
+        """
+        self._clear_viewer(viewer)
+        self._next(viewer)
+        print(f'next')
+
+    def previous(self, viewer):
+        """
+        Move to previous pair. Will be bound to key 'd'
+        """
+        self._clear_viewer(viewer)
+        self._previous(viewer)
+        print(f'previous')
+    
+
+    def add_id_swap(self, viewer):
+        """
+        Get the time frame at which ID swap happended
+        """
+        current = viewer.dims.current_step[0]
+        t0 = self.df[self.t_start][self.i]
+        t = current + t0
+        self.df[self.swap_col][self.i].append(t)
+    
+
+    # Utility functions
+    # -----------------
+
+    def _annotate(self, ann, viewer):
+        word = lambda a : 'correct' if a == 1 else 'incorrect'
+        self._clear_viewer(viewer)
+        self.df.at[self.i, self.out_col] = ann
+        print(f'Track {self.current[0]} at time {self.current[1]} was marked {word(ann)}')
+        self._get_score()
+        if self.save_path is not None:
+            self.df.to_csv(self.save_path) 
+        self._next(viewer)
+
+
+    def _get_score(self):
+            """
+            Get the proportion of correctly scored tracks
+            """
+            self.score = np.divide(self.df[self.out_col].sum(), len(self.df))
+    
+    
+    def _next(self, viewer):
+        if self.i + 1 < len(self.df):
+            self.i = self.i + 1
+            ID = self.df[self.id_col][self.i]
+            t = self.df[self.time_col][self.i]
+            self.current = (ID, t)
+            self._clear_viewer(viewer)
+            self._show_track(viewer)
+            print(f'Showing track {self.i+1} of {len(self.df)}')
+            self._check_ann_status()
+        else:
+            print('Final track in series, press a to go backwards')
+            self._check_ann_status()
+ 
+
+    def _previous(self, viewer):
+        if self.i - 1 >= 0:
+            self.i = self.i - 1
+            ID = self.df[self.id_col][self.i]
+            t = self.df[self.time_col][self.i]
+            self.current = (ID, t)
+            self._clear_viewer(viewer)
+            self._show_track(viewer)
+        else:
+            msg0 = 'First track in series, press d to move on '
+            msg1 = 'or y/no to annotate and move on'
+            print(msg0 + msg1)
+
+
+    def _show_track(self, viewer):
+        i = self.i
+        ID, t = self.current
+        name = f'ID-{ID}_t-{t}'
+        # add volume
+        viewer.add_image(self.array[i], name='v_' + name, 
+                         scale=self.im_scale)
+        # add tracks layers
+        viewer.add_tracks(self.tracks[i], name='t_' + name)
+
+
+    def _clear_viewer(self, viewer):
+        for _ in range(len(self.viewer.layers)):
+            viewer.layers.pop(0)
+
+
+    def _check_ann_status(self):
+        out = self.df[self.out_col].values
+        if None not in out:
+            print('All tracks have been annotated')
+            print(f'Final score is {self.score * 100} %')
+        elif None in out and self.i + 1 > len(out):
+            not_done = []
+            for i, o in enumerate(out):
+                if o == None:
+                    not_done.append(i)
+            if len(not_done) == 1:
+                print(f'Track {not_done[0]} of {len(out)} has not yet been annotated')
+            if len(not_done) > 1:
+                print(f'Tracks {not_done} of {len(out)} have not yet been annotated')
+
+    
+# -----------------------------------------------------------------------------
+# CostEvaluation class
+# --------------------
+
+class CostEvaluation(TrackViewer):
+    def __init__(self,
+                 tracks, 
+                 array, 
+                 shape, 
+                 im_scale=(1, 1, 1, 4),
+                 id_col='ID', 
+                 time_col='t', 
+                 out_col='correct'):
+        super().__init__(
+                       hypercubes=None, 
+                       tracks_list=None, 
+                       df=None, 
+                       save_path=None,
+                       im_scale=im_scale,
+                       id_col=id_col, 
+                       time_col=time_col, 
+                       out_col=out_col
+                       )
+        self.all_tracks = tracks
+        self.image = array
+        self.shape = shape
+        self.RTE = None
+        self.cost = None
+
+
+    def annotate_all(self):
+        tracks = get_tracks(self.all_tracks, id_col='parent', time_col='t', w_prop=False)
+        with napari.gui_qt():
+            self.viewer = napari.Viewer()
+            self.viewer.add_image(self.image, scale=self.im_scale)
+            self.viewer.add_tracks(tracks, colormap='viridis')
+            self.viewer.bind_key('y', self._approve)
+            self.viewer.bind_key('n', self._disapprove)
+
+
+    # For Key Binding
+    # ---------------
+
+    def _approve(self, viewer):
+        self._clear_viewer(viewer)
+        self.viewer.bind_key('y', None)
+        self.viewer.bind_key('n', None)
+        self.RTE = RandomTracksEngine(self.all_tracks, 
+                                      self.image, 
+                                      self.shape)
+        hcs, random_tracks = self.RTE.add_tracks(30)
+        info = self.RTE.tracks_info
+        self.data = hcs, random_tracks, info
+        self.annotate()
+        self.cost = 1 - self.score
+
+
+    def _disapprove(self, viewer):
+        self._clear_viewer(viewer)
+        self.cost = 1
+        self.viewer.bind_key('n', None)
+        self.viewer.bind_key('y', None)
+        
+
+
+# -----------------------------------------------------------------------------
+# Functions
+# ---------
+
+def annotate(
+             hypercubes, 
+             tracks_list, 
+             df, 
+             save_path,
+             im_scale=(1, 1, 1, 4),
+             id_col='ID',
+             time_col='t', 
+             out_col='correct'
+             ):
+    track_viewer = TrackViewer(
+                               hypercubes, 
+                               tracks_list, 
+                               df, 
+                               save_path,
+                               im_scale=im_scale,
+                               id_col=id_col, 
+                               time_col=time_col, 
+                               out_col=out_col)
+    track_viewer.annotate()

--- a/sampling.py
+++ b/sampling.py
@@ -1,0 +1,945 @@
+from data_io import dict_2_JSON_serializable
+from datetime import date
+from itertools import repeat
+import json
+import numpy as np
+from numpy import ndarray
+import os
+import pandas as pd 
+from pandas import DataFrame
+from pathlib import Path
+from skimage.measure import regionprops
+import time
+from toolz import curry
+from typing import Iterable, Union
+from view_tracks import get_tracks, add_track_length
+
+
+# ------------------------------
+# RANDOM SAMPLE & BOUNDING BOXES
+# ------------------------------
+
+def random_sample(
+                  df: DataFrame,
+                  array: ndarray, 
+                  name: str,
+                  n_samples: int,
+                  frames: int =10, 
+                  box: int =60,
+                  id_col: str ='ID', 
+                  time_col: str ='t', 
+                  array_order: Iterable[str] =('t', 'x', 'y', 'z'), 
+                  scale: Iterable[int] =(1, 1, 1, 4), 
+                  non_tzyx_col: Union[Iterable[str], str, None] = None,
+                  seed: Union[int, None] =None,
+                  weights: Union[str, None] =None,
+                  max_lost_prop: Union[float, None] =None,
+                  **kwargs
+                  ):
+    """
+    Take a random sample from a 
+    """
+    shape = array.shape
+    _frames = np.floor_divide(frames, 2)
+    _box = np.floor_divide(box, 2)
+    # this is the image shape scaled to the data
+    scaled_shape = [s * scale[i] # scaled shape in image order
+                    for i, s in enumerate(shape)]
+    # curried function. Add important info for later
+    _add_info = _add_sample_info(
+                                 id_col, 
+                                 time_col,
+                                 _frames, 
+                                 max_lost_prop)
+    if seed is None:
+        seed = np.random.randint(0, 100_000)
+    # initalise the sample dict 
+    #   Why? The function is recursive (if max_lost_prop < 1.0)
+    #       initialising within isnt an option.
+    #       and mutable defaults are just silly
+    sample = {}
+    sample = _sample(
+                     sample, 
+                     df, 
+                     n_samples, 
+                     seed, 
+                     array_order, 
+                     scaled_shape, 
+                     name, 
+                     weights, 
+                     _add_info
+                     )
+    # sample scale is the scale that brings the data to the image
+    sample = _estimate_bounding_boxes(
+                                      sample, 
+                                      shape,
+                                      id_col, 
+                                      time_col, 
+                                      _frames, 
+                                      _box,
+                                      array_order, 
+                                      non_tzyx_col, 
+                                      scale
+                                      )
+    sample['info'] = _tracks_df(df, sample, id_col, time_col, array_order)
+    return sample
+
+
+
+# Sampling
+# --------
+
+def _sample(
+            sample, 
+            df, 
+            n_samples, 
+            seed, 
+            array_order, 
+            scaled_shape, 
+            name, 
+            weights, 
+            _add_info):
+    """
+    select random sample
+    """
+    for i, col in enumerate(array_order):
+        df = df.loc[(df[col] < scaled_shape[i])].copy()
+    if n_samples == 0:
+        print(f"Random {name} obtained")
+        pairs = list(sample.keys())
+        return sample
+    elif n_samples < 0:
+        # remove excess - print so that I can see if this is ever executed
+        #   I don't think it will be, but just in case
+        excess = abs(n_samples)
+        print(f"Removing {excess} excess {name}")
+        pairs = list(sample.keys())
+        for i in range(excess):
+            del sample[pairs[i]]
+        return sample
+    # If we don't get enough samples 
+    #   (e.g., chooses a time point too near start or end)
+    #   the function will call itself (with remainder samples to obtain)
+    # NOTE: the max proportion of frames that can be lost in the track can be set 
+    else:
+        print(f'Sampling {n_samples}...')
+        if weights is not None:
+            w = df[weights].values
+        else:
+            w = None
+        #iamkitten
+        kittens_sample = df.sample(n=n_samples, weights=w, random_state=seed) # kitten's
+        num_obtained = _add_info(kittens_sample, df, sample)
+        n_samples = n_samples - num_obtained
+        # this whole recursion thing doesnt really work when you use the same seed
+        seed += 1 
+        return _sample(
+                       sample, 
+                       df, 
+                       n_samples, 
+                       seed, 
+                       array_order, 
+                       scaled_shape, 
+                       name, 
+                       weights, 
+                       _add_info)
+
+
+# referenced in random_sample(...)
+@curry
+def _add_sample_info(id_col, 
+                     time_col,
+                     _frames, 
+                     max_lost_prop,
+                     sample_df, 
+                     df, 
+                     sample
+                     ):
+    counter = 0
+    for i in range(len(sample_df)):
+        ID = sample_df[id_col].values[i]
+        t = sample_df[time_col].values[i]
+        pair = (ID, t)
+        lil_df = df.loc[
+            (df[id_col] == ID) & 
+            (df[time_col] >= t - _frames) & 
+            (df[time_col] <= t + _frames)
+            ]
+        right_len = len(lil_df) >= np.floor((1-max_lost_prop) * (_frames * 2 + 1))
+        right_len = right_len and len(lil_df) <= _frames * 2 + 1
+        new_pair = pair not in sample.keys()
+        row = df.loc[(df[id_col]==pair[0]) & 
+                     (df[time_col]==pair[1])].copy()
+        right_row_len = len(row) == 1
+        if right_len & new_pair & right_row_len:
+            lil_df = lil_df.reset_index(drop=True)
+            try:
+                lil_df = lil_df.drop(columns=['Unnamed: 0'])
+            except:
+                pass
+            sample[pair] = {'df': lil_df}
+            counter += 1
+    return counter
+
+
+# Bounding Boxes
+# --------------
+
+# referenced in random_sample(...)
+def _estimate_bounding_boxes(
+                             sample, 
+                             shape,
+                             id_col, 
+                             time_col, 
+                             _frames, 
+                             _box,
+                             array_order, 
+                             non_tzyx_col, 
+                             image_scale
+                             ):
+    print('Finding bounding boxes...')     
+    hc_shape, sample_scale = _box_shape(
+                                        array_order, 
+                                        time_col, 
+                                        non_tzyx_col, 
+                                        _frames, 
+                                        _box, 
+                                        shape, 
+                                        image_scale
+                                        ) 
+    coords_cols = _coords_cols(array_order, non_tzyx_col, time_col)
+    pairs = sample.keys()
+    for pair in pairs:
+        df = sample[pair]['df']
+        row = df.loc[(df[id_col]==pair[0]) & 
+                     (df[time_col]==pair[1])].copy()
+        sample[pair]['corr'] = {}
+        # initialise the bounding box info
+        sample[pair]['b_box'] = {}
+        # TIME SLICE
+        # find last time frame index
+        for i, col in enumerate(array_order):
+            if col == time_col:
+                t_lim = shape[i] - 1
+        sample = _time_slice(
+                             pair, 
+                             sample, 
+                             df, 
+                             t_lim, 
+                             time_col, 
+                             _frames, 
+                             hc_shape
+                             )
+        # SPATIAL COORDS SLICES
+        sample = _coords_slices(
+                                array_order, 
+                                coords_cols, 
+                                hc_shape, 
+                                sample_scale, 
+                                row, 
+                                _box, 
+                                image_scale, 
+                                sample,
+                                shape,
+                                df, 
+                                pair
+                                )
+        # NON SPATIAL OR TIME SLICES
+        sample = _non_tzyx_slices(sample, pair, non_tzyx_col)
+    return sample
+
+
+# referenced in _estimate_bounding_boxes
+def _box_shape(
+               array_order, 
+               time_col, 
+               non_tzyx_col, 
+               _frames, 
+               _box, 
+               shape, 
+               image_scale
+               ):
+    # get the scale that brings the data to the image
+    sample_scale = []
+    for i, col in enumerate(array_order):
+            s = np.divide(1, image_scale[i])
+            sample_scale.append(s)
+    # if necessary, change configuration of non_tzyx_col
+    if not isinstance(non_tzyx_col, Iterable):
+        non_tzyx_col = [non_tzyx_col]
+    # get the hypercube shape
+    hc_shape = []
+    for i, col in enumerate(array_order):
+        if col == time_col:
+            scaled = np.multiply(_frames*2+1, sample_scale[i])
+            hc_shape.append(scaled)
+        elif col in non_tzyx_col:
+            scaled = np.multiply(shape[i]*2+1, sample_scale[i])
+            hc_shape.append()
+        else:
+            scaled = np.multiply(_box*2+1, sample_scale[i])
+            hc_shape.append(scaled)
+    hc_shape = np.floor(np.array(hc_shape)).astype(int)
+    return hc_shape, sample_scale
+
+
+# referenced in _estimate_bounding_boxes
+def _coords_cols(array_order, non_tzyx_col, time_col):
+    if isinstance(non_tzyx_col, Iterable):
+        coords_cols = non_tzyx_col.copy().append(time_col)
+    else:
+        coords_cols = [col for col in array_order if col \
+                    not in [time_col, non_tzyx_col]]
+    return coords_cols
+
+
+# referenced in _estimate_bounding_boxes
+def _time_slice(
+                pair, 
+                sample, 
+                df, 
+                t_lim, 
+                time_col, 
+                _frames, 
+                hc_shape
+                ):
+    # get the estimated time index
+    t_min, t_max = pair[1] - _frames, pair[1] + _frames
+    # correct the min time index
+    if t_min < 0:
+        t_min = 0
+    # correct the max time index
+    if t_max > t_lim:
+        t_max = t_lim
+    t_max += 1
+    # correct the track data for the bounding box
+    df = sample[pair]['df']
+    df[time_col] = df[time_col] - t_min 
+    sample[pair]['b_box'][time_col] = slice(t_min, t_max)
+    sample[pair]['df'] = df
+    return sample
+
+
+# referenced in _estimate_bounding_boxes
+def _coords_slices(
+                   array_order, 
+                   coords_cols, 
+                   hc_shape, 
+                   sample_scale, 
+                   row, 
+                   _box, 
+                   image_scale, 
+                   sample,
+                   shape,
+                   df, 
+                   pair
+                   ):
+    df = sample[pair]['df']
+    for i, coord in enumerate(array_order):
+        if coord in coords_cols:
+            sz = hc_shape[i]
+            # scale the tracks value to fit the image
+            sample_2_box_scale = sample_scale[i]
+            value = np.multiply(row[coord].values[0], sample_2_box_scale)
+            # scale the bounding box for the image coordinate
+            box = np.multiply(_box, sample_2_box_scale)
+            col_min = np.floor(value - box).astype(int)
+            col_max = np.floor(value + box).astype(int)
+            sz1 = col_max - col_min
+            diff = sz1 - sz
+            col_min, col_max = _correct_diff(diff, col_min, col_max)
+            # slice corrections
+            box_to_tracks_scale = image_scale[i]
+            # get the max and min values for track vertices in box scale
+            max_coord = np.multiply(df[coord].max(), sample_2_box_scale)
+            min_coord = np.multiply(df[coord].min(), sample_2_box_scale)
+            # correct box shape if the box is too small to capture the 
+            # entire track segment
+            if min_coord < col_min:
+                col_min = np.floor(min_coord).astype(int)
+            if max_coord > col_max:
+                col_max = np.ceil(max_coord).astype(int)
+            if col_min < 0:
+                col_min = 0
+            if col_max > shape[i]:
+                col_max = shape[i]
+            sample[pair]['b_box'][coord] = slice(col_min, col_max)
+            # need to construct correctional slices for getting 
+            # images that are smaller than the selected cube volume
+            # into the cube. 
+            sz1 = col_max - col_min
+            diff = sz - sz1
+            # the difference should not be negative 
+            #m0 = 'The cube dimensions should not be '
+            #m1 = 'greater than the image in any axis: '
+            #m2 = f'{col_min}:{col_max} for coord {coord}'
+            #assert diff >= 0, m0 + m1 + m2
+            # correct the position data for the frame
+            c_min = (col_min * box_to_tracks_scale)
+            df[coord] = df[coord] - c_min 
+    return sample
+
+
+# referenced in _coords_slices
+def _correct_diff(diff, col_min, col_max):
+    odd = diff % 2
+    if diff < 0:
+        diff = abs(diff)
+        a = -1
+    else:
+        a = 1
+    adj = np.floor_divide(diff, 2)
+    col_min = col_min - (adj * a)
+    if odd:
+        adj = adj + 1
+        col_max = col_max - (adj * a)
+    else:
+        col_max = col_max - (adj * a)
+    return col_min, col_max
+
+
+# referenced in _estimate_bounding_boxes
+def _non_tzyx_slices(sample, pair, non_tzyx_col):
+    if non_tzyx_col is not None:
+        for col in non_tzyx_col:
+            sample[pair]['b_box'][col] = slice(None)
+    return sample
+
+
+# referenced in random_sample(...)
+def _tracks_df(df, sample, id_col, time_col, array_order):
+    info = []
+    pairs = sample.keys()
+    for pair in pairs:
+        # get the row of info about the sampled segment
+        row = df.loc[(df[id_col]==pair[0]) & 
+                     (df[time_col]==pair[1])].copy()
+        # add summary stats for the track
+        for col in sample[pair]['df'].columns.values:
+            if isinstance(col[0], str):
+                pass
+            else:
+                mean = sample[pair]['df'][col].mean()
+                sem = sample[pair]['df'][col].sem()
+                mean_name = col + '_seg_mean'
+                sem_name = col + '_seg_sem'
+                row.loc[:, mean_name] = mean
+                row.loc[:, sem_name] = sem
+        # add bounding box information 
+        for coord in array_order:
+            s_ = sample[pair]['b_box'][coord]
+            s_min = s_.start
+            n_min = coord + '_start'
+            s_max = s_.stop
+            n_max = coord + '_stop'
+            row.loc[:, n_min] = [s_min,]
+            row.loc[:, n_max] = [s_max,]
+        num_frames = sample[pair]['df'][time_col].max() \
+                    - sample[pair]['df'][time_col].min()
+        row.loc[:, 'frames'] = [num_frames,]
+        info.append(row)
+    info = pd.concat(info)
+    info = info.reset_index(drop=True)
+    info = info.drop(columns=['Unnamed: 0'])
+    return info 
+
+
+# -------------
+# SAMPLE TRACKS
+# -------------
+
+def sample_tracks(df: DataFrame,
+                  array: ndarray, 
+                  name: str,
+                  n_samples: int,
+                  frames: int =10, 
+                  box: int =60,
+                  id_col: str ='ID', 
+                  time_col: str ='t', 
+                  array_order: Iterable[str] =('t', 'x', 'y', 'z'), 
+                  scale: Iterable[int] =(1, 1, 1, 4), 
+                  non_tzyx_col: Union[Iterable[str], str, None] = None,
+                  seed: Union[int, None] =None,
+                  weights: Union[str, None] =None,
+                  max_lost_prop: Union[float, None] =None,
+                  min_track_length: Union[int, None] =20,
+                  **kwargs):
+    # calculate weights if required
+    coords_cols = _coords_cols(array_order, non_tzyx_col, time_col)
+    # well this was lazy (see below)
+    df = _add_disp_weights(df, coords_cols, id_col)
+    # older code from elsewhere, decided it wasn't hurting anything
+    if weights is not None:
+        if weights not in df.columns.values.tolist():
+            if weights == '2-norm':
+                df = _add_disp_weights(df, coords_cols, id_col)
+            else: 
+                m = 'Please use a column in the data frame or 2-norm to add distances'
+                raise(KeyError(m))
+    # filter for min track length
+    df = add_track_length(df, id_col, new_col='track_length') 
+    if min_track_length is not None:
+        df = df.loc[df['track_length'] >= min_track_length, :]
+    # get the sample
+    sample = random_sample(
+                           df,
+                           array, 
+                           name,
+                           n_samples,
+                           frames, 
+                           box,
+                           id_col, 
+                           time_col, 
+                           array_order, 
+                           scale, 
+                           non_tzyx_col,
+                           seed,
+                           weights,
+                           max_lost_prop,
+                           **kwargs)
+    # add track arrays ready for input to napari tracks layer 
+    sample = _add_track_arrays(sample, id_col, time_col, coords_cols)
+    return sample
+
+
+def _add_disp_weights(df, coords_cols, id_col):
+        """
+        Get L2 norm of finite difference across x,y,z for each track point
+        These will be used as weights for random track selection.
+        """
+        coords = coords_cols
+        weights = []
+        for ID in list(df[id_col].unique()):
+            # get the finite difference for the position vars
+            diff = df.loc[(df[id_col] == ID)][coords].diff()
+            diff = diff.fillna(0)
+            # generate L2 norms for the finite difference vectors  
+            n2 = list(np.linalg.norm(diff.to_numpy(), 2, axis=1))
+            weights.extend(n2)
+        v0 = len(weights)
+        v1 = len(df)
+        m = 'An issue has occured when calculating track displacements'
+        m = m + f': the length of the data frame ({v1}) does not equal '
+        m = m + f'that of the displacements ({v0})'
+        assert v0 == v1, m 
+        df['2-norm'] = weights
+        return df
+
+
+def _add_track_arrays(sample, id_col, time_col, coords_cols):
+    cols = [id_col, time_col]
+    for c in coords_cols:
+        cols.append(c)
+    for pair in sample.keys():
+        if isinstance(pair, tuple):
+            df = sample[pair]['df']
+            tracks = df[cols].to_numpy()
+            sample[pair]['tracks'] = tracks
+    return sample
+
+
+# -------------------------
+# SAMPLE TRACK TERMINATIONS
+# -------------------------
+
+def sample_track_terminations(df: DataFrame,
+                              array: ndarray, 
+                              name: str,
+                              n_samples: int,
+                              frames: int =10, 
+                              box: int =60,
+                              id_col: str ='ID', 
+                              time_col: str ='t', 
+                              array_order: Iterable[str] =('t', 'x', 'y', 'z'), 
+                              scale: Iterable[int] =(1, 1, 1, 4), 
+                              non_tzyx_col: Union[Iterable[str], str, None] = None,
+                              seed: Union[int, None] =None,
+                              weights: Union[str, None] =None,
+                              max_lost_prop: Union[float, None] =None,
+                              min_track_length: Union[int, None] =20,
+                              **kwargs
+                              ):
+    # filter data frame for terminations
+    #
+    # get sample
+    sample = sample_tracks(
+                           df,
+                           array, 
+                           name,
+                           n_samples,
+                           frames, 
+                           box,
+                           id_col, 
+                           time_col, 
+                           array_order, 
+                           scale, 
+                           non_tzyx_col,
+                           seed,
+                           weights,
+                           max_lost_prop,
+                           min_track_length,
+                           **kwargs
+                           )
+    return sample
+
+
+# --------------
+# SAMPLE OBJECTS
+# --------------
+
+
+def sample_objects_bad(
+                  df: DataFrame,
+                  array: ndarray, 
+                  name: str,
+                  n_samples: int,
+                  tracks_df: Union[None, pd.DataFrame] =None,
+                  frames: int =10, 
+                  box: int =60,
+                  id_col: str ='ID', 
+                  time_col: str ='t', 
+                  array_order: Iterable[str] =('t', 'x', 'y', 'z'), 
+                  scale: Iterable[int] =(1, 1, 1, 4), 
+                  non_tzyx_col: Union[Iterable[str], str, None] = None,
+                  seed: Union[int, None] =None,
+                  weights: Union[str, None] =None,
+                  max_lost_prop: Union[float, None] =None,
+                  **kwargs
+                  ):
+    # probably need to add some preprocessing (perhaps use labels array to produce df for this)
+    sample = random_sample(
+                           df,
+                           array, 
+                           name,
+                           n_samples,
+                           frames, 
+                           box,
+                           id_col, 
+                           time_col, 
+                           array_order, 
+                           scale, 
+                           non_tzyx_col,
+                           seed,
+                           weights,
+                           max_lost_prop,
+                           **kwargs)
+    if tracks_df is not None:
+        for key in sample:
+            if isinstance(key, tuple):
+                lil_tracks = tracks_df.copy() 
+                for c in array_order:
+                    if c != time_col:
+                        start = sample[key]['b_box'][c].start
+                        stop = sample[key]['b_box'][c].stop
+                        lil_tracks = lil_tracks.loc[(lil_tracks[c] > start) & (lil_tracks[c] < stop)]
+                    else:
+                        start = sample[key]['b_box'][c].start - np.floor_divide(frames, 2)
+                        stop = sample[key]['b_box'][c].start + np.floor_divide(frames, 2)
+                sample[key]['df'] = lil_tracks
+        coords_cols = _coords_cols(array_order, non_tzyx_col, time_col)
+        sample = _add_track_arrays(sample, id_col, time_col, coords_cols)
+    return sample
+
+
+def sample_objects_old(
+                   objects,
+                   tracks,
+                   labels,
+                   array, 
+                   name,
+                   n_samples,
+                   frames, 
+                   box,
+                   id_col, 
+                   time_col, 
+                   array_order, 
+                   scale, 
+                   non_tzyx_col,
+                   seed,
+                   max_lost_prop=1.0,
+                   **kwargs
+                   ):
+    shape = array.shape
+    _frames = np.floor_divide(frames, 2)
+    _box = np.floor_divide(box, 2)
+    # sample objects
+    #iamkitten
+    kittens_sample = objects.sample(n=n_samples, random_state=seed) # kitten's
+    sample = _get_object_tracks(labels,
+                       kittens_sample, 
+                       tracks, 
+                       shape,
+                       _frames, 
+                       _box, 
+                       scale, 
+                       id_col, 
+                       time_col, 
+                       array_order, 
+                       non_tzyx_col
+                       )
+    return sample
+
+
+def _get_object_tracks(labels,
+                       df, 
+                       tracks, 
+                       shape,
+                       _frames, 
+                       _box, 
+                       scale, 
+                       id_col, 
+                       time_col, 
+                       array_order, 
+                       non_tzyx_col
+                       ):
+    # some scaled values for later
+    # this is the image shape scaled to the data
+    scaled_shape = [np.round(s * scale[i]).astype(int) # scaled shape in image order
+                    for i, s in enumerate(shape)]
+    inv_scale = np.divide(1, scale)
+    hlf_hc = []
+    for c in array_order:
+        if c == time_col:
+            n = _frames
+        else:
+            n = _box
+        hlf_hc.append(n)
+    # generate sample dict
+    sample = {}
+    df = df.reset_index(drop=True)
+    df['frames'] = [None] * len(df)
+    df['n_objects'] = [None] * len(df)
+    df['t_start'] = [None] * len(df)
+    # go through the sample and compose bounding boxes
+    for idx in df.index:
+        point_coords = []
+        # get pair info for each sampled object
+        # used as key for each object
+        pair = (df.loc[idx, id_col], df.loc[idx, time_col])
+        sample[pair] = {}
+        # generate df
+        lil_tracks = tracks.copy()
+        b_box = {}
+        for i, c in enumerate(array_order):
+            coord = df.loc[idx, c]
+            max_ = np.round(coord * scale[i] + hlf_hc[i])
+            min_ = np.round(coord * scale[i] - hlf_hc[i])
+            # correct for edges of image
+            if max_ >= scaled_shape[i]:
+                max_ = scaled_shape[i]
+            if min_ <  0:
+                min_ = 0
+            # get all tracks that live in this box 
+            lil_tracks = lil_tracks.loc[(lil_tracks[c] >= min_) & (lil_tracks[c] < max_)]
+            if c == time_col:
+                df.loc[i, 't_start'] = min_
+            lil_tracks[c] = lil_tracks[c] - min_ 
+            # same coordinates in image slicing scale
+            b_min = np.round(coord - hlf_hc[i] * inv_scale[i]).astype(int)
+            b_max = np.round(coord + hlf_hc[i] * inv_scale[i]).astype(int)
+            # correct for edges of image
+            if b_max >= shape[i]:
+                b_max = shape[i] - 1
+            if b_min < 0:
+                b_min = 0 
+            # add the coordinate slice to the pair info 
+            b_box[c] = slice(b_min, b_max)
+            # add the coordinate in image scale to the point coords
+            point_coords.append(coord - b_min)
+        # add the point to the pair
+        sample[pair]['point'] = np.array([point_coords])
+        # add the hypercube slices to the paie
+        sample[pair]['b_box'] = b_box
+        # add the tracks info to the pair
+        lil_tracks = lil_tracks.reset_index(drop=True)
+        sample[pair]['df'] = lil_tracks
+        # get the tracks array for input to napari
+        cols = [id_col, time_col]
+        coord_cols = _coords_cols(array_order, non_tzyx_col, time_col)
+        for c in coord_cols:
+            cols.append(c)
+        only_tracks = lil_tracks[cols].to_numpy()
+        sample[pair]['tracks'] = only_tracks
+    # add the sample info to the sample dict
+    sample['info'] = df
+    return sample
+        
+
+
+def sample_objects(
+                   tracks,
+                   labels,
+                   array, 
+                   name,
+                   n_samples,
+                   frames, 
+                   box,
+                   id_col, 
+                   time_col, 
+                   array_order, 
+                   scale, 
+                   non_tzyx_col,
+                   seed,
+                   max_lost_prop,
+                   **kwargs
+                   ): 
+    #
+    _frames = np.floor_divide(frames, 2)
+    _box = np.floor_divide(box, 2)
+    objs = get_objects_without_tracks(
+                               labels, 
+                               tracks, 
+                               id_col, 
+                               time_col, 
+                               array_order, 
+                               scale,
+                               _frames, 
+                               _box
+                               )
+    #
+    try:
+        kittens_sample = objs.sample(n=n_samples, random_state=seed)
+    except:
+        kittens_sample = objs
+        print(len(objs))
+    #
+    shape = labels.shape
+    sample = _get_object_tracks(labels,
+                       kittens_sample, 
+                       tracks, 
+                       shape,
+                       _frames, 
+                       _box, 
+                       scale, 
+                       id_col, 
+                       time_col, 
+                       array_order, 
+                       non_tzyx_col
+                       )
+    return sample
+
+            
+def get_objects_without_tracks(
+                               labels, 
+                               tracks, 
+                               id_col, 
+                               time_col, 
+                               array_order, 
+                               scale,
+                               _frames, 
+                               _box
+                               ):
+    """
+    The 
+    """
+    df = {c:[] for c in array_order}
+    df[id_col] = []
+    df['area'] = []
+    coord_cols = [c for c in array_order if c != time_col]
+    coord_scale = [scale[i] for i, c in enumerate(array_order) if c != time_col]
+    for t in range(labels.shape[0] - 1):
+        try:
+            frame = np.array(labels[t, ...])
+            # get the tracks at this point in time 
+            t_trk = tracks.copy()
+            t_trk = t_trk.loc[t_trk[time_col] == t]
+            # get the properties of objects in the frame
+            props = regionprops(frame)
+            # go through properties. 
+            no_tracks = []
+            for p in props:
+                label = p['label']
+                bbox = p['bbox']
+                ct = t_trk.copy()
+                # get any tracks in the bounding box for this obj
+                for i, c in enumerate(coord_cols):
+                    min_ = bbox[i] * coord_scale[i]
+                    max_ = bbox[i + len(coord_cols)] * coord_scale[i]
+                    ct = ct.loc[(ct[c] >= min_) & (ct[c] < max_)]
+                # if there are no tracks in the bbox, add to the list
+                if len(ct) == 0:
+                    no_tracks.append(label)
+            # based on list entries, make dataframe for objects
+            for p in props:
+                if p['label'] in no_tracks:
+                    df[time_col].append(t)
+                    for i, c in enumerate(coord_cols):
+                        df[c].append(p['centroid'][i])
+                    df[id_col].append(p['label'])
+                    df['area'].append(p['area'])
+        except KeyError:
+            print(t)
+    df = pd.DataFrame(df)
+    print(f'Found {len(df)} untracked objects')
+    return df
+        
+
+            #trk_vert = np.zeros(frame.shape, dtype=bool)
+            #s_ = [np.round(t_trk[c].values * inv_scale[i]).astype(int) for i, c in enumerate(array_order)]
+            #s_ = np.array(s_)
+            #trk_vert[s_] = True
+            #trk_obj = np.where(trk_vert == True, frame, trk_vert)
+            #IDs = np.unique(trk_obj).tolist()
+
+ 
+        
+        
+
+
+
+
+
+
+         
+
+
+
+# -----------
+# SAVE SAMPLE 
+# -----------
+
+def save_sample(save_name, sample):
+    """
+    Parse sample info to JSON serialisable and save
+    NEEDS DEBUGGING GAVE UP 
+        - TE: int64 not seriablisable (even after dataframes corrected)
+    """
+    sample = sample.copy()
+    d = date.today().strftime('%y%m%d')
+    if not save_name.endswith('.sample'):
+        save_name = save_name + '.sample'
+    if os.path.exists(save_name):
+        p = Path(save_name)
+        #name = p.
+    os.makedirs(save_name, exist_ok=True)
+    index_path = os.path.join(save_name, 'file_index.json')
+    info_path = os.path.join(save_name, 'info.csv')
+    
+    
+    
+    #JSONified = dict_2_JSON_serializable(sample)
+    #new = {}
+    #for key in JSONified.keys():
+        #if isinstance(key, tuple):
+         #   nk = str(key)
+        #else:
+        #    nk = key
+        #new[nk] = JSONified[key]
+   # print(new)
+    #with open(save_path, 'w') as f:
+     #   json.dump(new, f, indent=4)
+
+
+def read_sample(sample_path):
+    """
+    Parse sample info from .sample 'file'
+    """
+    pass
+
+
+def save_sample_array(save_path, sample, array):
+    """
+    Save image data corresponding to a sample
+    """
+    pass
+

--- a/view_tracks.py
+++ b/view_tracks.py
@@ -49,7 +49,7 @@ def get_tracks(df, min_frames=20, id_col='particle', time_col='frame',
     dict(df_filtered): dict
         dict containing the properties for napari
     """
-    time_0 = time.time()
+
     id_array = df[id_col].to_numpy()
     track_count = np.bincount(id_array)
     df['track length'] = track_count[id_array]
@@ -58,12 +58,19 @@ def get_tracks(df, min_frames=20, id_col='particle', time_col='frame',
     data_cols = [id_col, time_col] + list(coord_cols)
     track_data = df_filtered[data_cols].to_numpy()
     track_data[:, -3:] *= scale
-    print(f'{np.sum(track_count >= min_frames)} tracks found in '
-          f'{time.time() - time_0} seconds')
+    print(f'{np.sum(track_count >= min_frames)} tracks found with '
+          f'>= {min_frames} vertices')
     if w_prop:
         return track_data, dict(df_filtered)
     else:
         return track_data
+
+
+def add_track_length(df, id_col, new_col='track_length'):
+    id_array = df[id_col].to_numpy()
+    track_count = np.bincount(id_array)
+    df[new_col] = track_count[id_array]
+    return df
 
 
 def save_tracks(tracks, name='tracks-for-napari.csv'):


### PR DESCRIPTION
## Description
This PR makes three forms of tracking accuracy evaluation possible:
1) Evaluation of false positives (swaps between adjacent objects) and false negatives (incorrect terminations) in a random sample of track segments. This has an option for weighting sampling by linkage length (speed).
2) Evaluation of false positives and false negatives in a random sample of track terminations
3) Evaluation of the correctness of untracked objects

__NB:__ This replaces the functionality of `random_track_engine` and `annotate_tracks`

## Usage
- `-i`, `--image` =  image path
- `-t`, `--tracks` = tracks csv path
- `-s`, `--save` = directory to which to save output (a new folder will be created within based on a naming scheme)
- `-l`, `--labels` = labels path

```bash
python evaluate_tracks.py \
    -i /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3.zarr \
    -t /Users/amcg0011/GitRepos/pia-tracking/20200918-130313/tracks.csv \
    -s /Users/amcg0011/Data/pia-tracking/ \
    -l /Users/amcg0011/Data/pia-tracking/200519_IVMTR69_Inj4_dmso_exp3_labels.zarr
```


## Issues
- sometimes the random sample of tracks simply fails to show the tracks in the sample. Instead you get a funny error message about incorrect dimensions. If there is no error message and the tracks appear, then you will be able to annotate the entire sample without issue. 

## To Do
- Re-add the logic for adding the track segment's average linkage length to sample info data frame
- General diagnostic information about tracks (not human annotated) 
   - How long/fast on average
   - How many tracks identified 
   - How many objects untracked
- Finish developing save function for saving sample info and write function for parsing this info from file
